### PR TITLE
GHDL work-around for language version 2002

### DIFF
--- a/PsiSim.tcl
+++ b/PsiSim.tcl
@@ -175,7 +175,11 @@ namespace eval psi::sim {
 			}
 		} elseif {$Simulator == "GHDL"} {
 			if {$language == "vhdl"} {
-				if {$langVersion != "2008"} {
+				if {$langVersion == "2002"} {
+					# compile for 2002 (to make sure no 2008 features are used) but compile again for 2008
+					# since we assume most testbenches will use that and ghdl does not support mixing versions
+					exec ghdl -a --ieee=synopsys --std=02 -fexplicit -frelaxed-rules -Wno-shared -Wno-hide --work=$lib -P. $path
+				} elseif {$langVersion != "2008"} {
 					sal_print_log "ERROR: VHDL Version $langVersion not supported for GHDL"
 				}
 				exec ghdl -a --ieee=synopsys --std=08 -frelaxed-rules -Wno-shared -Wno-hide --work=$lib -P. $path


### PR DESCRIPTION
GHDL does not support mixing VHDL 2002 and 2008, unfortunately.
I.e., code compiled for these language versions goes into
different output products (work-obj93.cf and work-obj08.cf,
respectively [versions 93 and 02 *are* compatible and both go
into the '93' output product]).

Some libraries ask PsiSim to be compiled against 2002 to ensure
compatibility with Xilinx tools. However, most actual test code
requires vhdl-2008.

This patch implements a work-around when language version 2002 is
requested. In this case, compilation is performed twice; for
2002 AND 2008:
 - compilation against 2002 ensures no 2008 features are used
 - compilation against 2008 ensures the compiled code can be used
   by other code that requires vhdl 2008 (such as test benches etc.)

This patch only affects PsiSim's GHDL-mode of operation.