### PR TITLE
Fix for Vivado when 'langArg' variable is empty.

### DIFF
--- a/PsiSim.tcl
+++ b/PsiSim.tcl
@@ -193,7 +193,8 @@ namespace eval psi::sim {
 				sal_print_log "ERROR: Verilog currently not supported for Vivado, request this feature from the developers"
 				sal_print_log ""
 			}
-			exec xvhdl --lib=$lib --work $lib=$lib $langArg $path
+			# langArg may be empty and confuse xvhdl; therefore we 'eval'...
+			eval exec xvhdl --lib=$lib --work $lib=$lib $langArg $path
 		} else {
 			puts "ERROR: Unsupported Simulator - sal_compile_file(): $Simulator"
 		}


### PR DESCRIPTION
fixed 'exec xvhdl ... $langArg ...' command (confused by empty langArg)

When 'langArg' is empty ("") then an empty filename is passed by
tclsh to xvhdl which will then fail.