### PR TITLE
Let GHDL install output products in proper subdirectories

### DIFF
--- a/PsiSim.tcl
+++ b/PsiSim.tcl
@@ -154,7 +154,6 @@ namespace eval psi::sim {
 			vlib $lib
 		} elseif {($Simulator == "GHDL") || ($Simulator == "Vivado")} {
 			file delete -force $lib
-			file mkdir $lib
 		} else {
 			puts "ERROR: Unsupported Simulator - sal_clean_lib(): $Simulator"
 		}
@@ -178,11 +177,13 @@ namespace eval psi::sim {
 				if {$langVersion == "2002"} {
 					# compile for 2002 (to make sure no 2008 features are used) but compile again for 2008
 					# since we assume most testbenches will use that and ghdl does not support mixing versions
-					exec ghdl -a --ieee=synopsys --std=02 -fexplicit -frelaxed-rules -Wno-shared -Wno-hide --work=$lib -P. $path
+					file mkdir $lib/v93
+					exec ghdl -a --ieee=synopsys --std=02 -fexplicit -frelaxed-rules -Wno-shared -Wno-hide --workdir=$lib/v93 --work=$lib -P. $path
 				} elseif {$langVersion != "2008"} {
 					sal_print_log "ERROR: VHDL Version $langVersion not supported for GHDL"
 				}
-				exec ghdl -a --ieee=synopsys --std=08 -frelaxed-rules -Wno-shared -Wno-hide --work=$lib -P. $path
+				file mkdir $lib/v08
+				exec ghdl -a --ieee=synopsys --std=08 -frelaxed-rules -Wno-shared -Wno-hide --workdir=$lib/v08 --work=$lib -P. $path
 			} else {
 				sal_print_log "ERROR: Verilog currently not supported for GHDL"
 				sal_print_log ""
@@ -249,7 +250,7 @@ namespace eval psi::sim {
 			if {$wave != ""} {
 				set wave " --wave=$wave"
 			} 
-			set cmd "ghdl --elab-run --ieee=synopsys --std=08 -frelaxed-rules -Wno-shared --work=$lib $tbName$tbArgs$stopTime$wave --ieee-asserts=disable"
+			set cmd "ghdl --elab-run --ieee=synopsys --std=08 -frelaxed-rules -Wno-shared --workdir=$lib/v08 --work=$lib $tbName$tbArgs$stopTime$wave --ieee-asserts=disable"
 			sal_print_log $cmd
 			set outp [eval "exec $cmd"]
 			sal_print_log $outp

--- a/PsiSim.tcl
+++ b/PsiSim.tcl
@@ -175,7 +175,11 @@ namespace eval psi::sim {
 			}
 		} elseif {$Simulator == "GHDL"} {
 			if {$language == "vhdl"} {
-				if {$langVersion != "2008"} {
+				if {$langVersion == "2002"} {
+					# compile for 2002 (to make sure no 2008 features are used) but compile again for 2008
+					# since we assume most testbenches will use that and ghdl does not support mixing versions
+					exec ghdl -a --ieee=synopsys --std=02 -fexplicit -frelaxed-rules -Wno-shared -Wno-hide --work=$lib -P. $path
+				} elseif {$langVersion != "2008"} {
 					sal_print_log "ERROR: VHDL Version $langVersion not supported for GHDL"
 				}
 				exec ghdl -a --ieee=synopsys --std=08 -frelaxed-rules -Wno-shared -Wno-hide --work=$lib -P. $path


### PR DESCRIPTION
This is consistent with other simulators and fixes the `clean_libraries` routine which would just remove library subdirs but not the GHDL products which end up in the CWD without this patch.

Also: create library subdir *before* compiling a library, not after cleaning it (the old behaviour broke ghdl the first time a library is complied and confused scripts that use a presence test of the library subdir as a flag whether to skip re-building a library).

NOTE: This PR **supersedes [PR#6](https://github.com/paulscherrerinstitute/PsiSim/pull/6)** (i.e., it includes [PR#6](https://github.com/paulscherrerinstitute/PsiSim/pull/6) -- ghdl workaround for language version 2002)